### PR TITLE
Update chef version dependency

### DIFF
--- a/health_inspector.gemspec
+++ b/health_inspector.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest"
   s.add_development_dependency "mocha"
   s.add_runtime_dependency "thor"
-  s.add_runtime_dependency "chef", "~> 0.10.8"
+  s.add_runtime_dependency "chef", "~> 10.14"
 end


### PR DESCRIPTION
The gemspec was using the 0.10.X version schema. Chef has moved to 10.X.Y, so this keeps users from upgrading chef.
