### PR TITLE
Pretty Printing hash differences

### DIFF
--- a/lib/health_inspector/checklists/base.rb
+++ b/lib/health_inspector/checklists/base.rb
@@ -69,7 +69,7 @@ module HealthInspector
               if original[key].kind_of?(Hash) && other[key].kind_of?(Hash)
                 memo[key] = diff(original[key], other[key])
               else
-                memo[key] = [original[key], other[key]]
+                memo[key] = {"server" => original[key],"local" => other[key]}
               end
             end
             memo
@@ -97,8 +97,38 @@ module HealthInspector
         puts color('bright fail', "- #{subject}")
 
         failures.each do |message|
-          puts color('bright yellow', "  #{message}")
+          if message.kind_of? Hash
+            puts color('bright yellow',"  has the following values mismatched on the server and repo\n")
+            print_failures_from_hash(message)
+          else
+            puts color('bright yellow', "  #{message}")
+          end
         end
+      end
+
+      def print_failures_from_hash(message, depth=0)
+        message.keys.each do |key|
+          print_key(key,depth)
+          if message[key].include? "server"
+            print_value_diff(message[key],depth)
+            message[key].delete_if {|k,v| k=="server"||"local"}
+            print_failures_from_hash(message[key],depth+1) if !message[key].empty?
+          else
+            print_failures_from_hash(message[key], depth+1)
+          end
+        end
+      end
+      def print_key(key,depth)
+        puts (color('bright yellow',"#{key} => ")).prepend(" "*(4*depth+2))
+      end
+
+      def print_value_diff(value,depth)
+        print (color('bright fail',"Server Value: ")).prepend(" "*(4*depth+4))
+        print value["server"]
+        print "\n"
+        print (color('bright fail',"Local Value:  ")).prepend(" "*(4*depth+4))
+        print value["local"] 
+        print "\n\n"
       end
 
       def load_ruby_or_json_from_local(chef_class, folder, name)

--- a/lib/health_inspector/checklists/base.rb
+++ b/lib/health_inspector/checklists/base.rb
@@ -111,9 +111,9 @@ module HealthInspector
           instance = chef_class.new
           instance.from_file(ruby_pathname.to_s)
         elsif json_pathname.exist?
-          instance = chef_class.json_create( JSON.parse( json_pathname.read ) )
+          instance = chef_class.json_create( Yajl::Parser.parse( json_pathname.read ) )
         elsif js_pathname.exist?
-          instance = chef_class.json_create( JSON.parse( js_pathname.read ) )
+          instance = chef_class.json_create( Yajl::Parser.parse( js_pathname.read ) )
         end
 
         instance ? instance.to_hash : nil

--- a/lib/health_inspector/checklists/environments.rb
+++ b/lib/health_inspector/checklists/environments.rb
@@ -16,7 +16,7 @@ module HealthInspector
       add_check "items are the same" do
         if item.server && item.local
           environment_diff = diff(item.server,item.local)
-          failure "#{environment_diff}\n" unless environment_diff.empty?
+          failure environment_diff unless environment_diff.empty?
         end
       end
 

--- a/lib/health_inspector/checklists/roles.rb
+++ b/lib/health_inspector/checklists/roles.rb
@@ -17,7 +17,8 @@ module HealthInspector
 
       add_check "items are the same" do
         if item.server && item.local
-          failure "#{item.server}\n  is not equal to\n  #{item.local}" unless item.server == item.local
+          roles_diff = diff( item.server, item.local)
+          failure roles_diff unless roles_diff.empty? 
         end
       end
 


### PR DESCRIPTION
I have added much improved printing of the calculated hash differences in the environments and roles, as well as diff'ing of the roles.

Sample output(w/o color):

```
- support-staging
  has the following values mismatched on the server and repo

  cookbook_versions =>
      hadoop =>
        Server Value: = 1.1.5
        Local Value:  = 1.1.3

      bluepill =>
        Server Value: = 1.0.6
        Local Value:

      hbase =>
        Server Value: = 1.1.2
        Local Value:  = 1.1.1

      zookeeper =>
        Server Value: = 1.1.4
        Local Value:  = 1.1.2
```
