### PR TITLE
Cookbook checksum comparison check

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+## 0.2.0 ( 2012-09-25 )
+
+* Add a better diff output.
+* Add diff output to data bag items.
+* Switch to yajl-ruby to fix JSON parsing issues (Chef uses this also).
+
 ## 0.1.0 ( 2012-09-24 )
 
 * Bump Chef dependency version up to 10.14

--- a/health_inspector.gemspec
+++ b/health_inspector.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "mocha"
+
   s.add_runtime_dependency "thor"
   s.add_runtime_dependency "chef", "~> 10.14"
+  s.add_runtime_dependency "yajl-ruby"
 end

--- a/lib/health_inspector.rb
+++ b/lib/health_inspector.rb
@@ -11,6 +11,8 @@ require "health_inspector/checklists/data_bag_items"
 require "health_inspector/checklists/environments"
 require "health_inspector/checklists/roles"
 require "health_inspector/cli"
+require 'chef/rest'
+require 'chef/checksum_cache'
 require "json"
 
 module HealthInspector

--- a/lib/health_inspector/checklists/base.rb
+++ b/lib/health_inspector/checklists/base.rb
@@ -106,27 +106,29 @@ module HealthInspector
         end
       end
 
-      def print_failures_from_hash(message, depth=0)
+      def print_failures_from_hash(message, depth=2)
         message.keys.each do |key|
           print_key(key,depth)
+
           if message[key].include? "server"
             print_value_diff(message[key],depth)
-            message[key].delete_if {|k,v| k=="server"||"local"}
-            print_failures_from_hash(message[key],depth+1) if !message[key].empty?
+            message[key].delete_if { |k,v| k == "server" || "local" }
+            print_failures_from_hash(message[key], depth + 1) unless message[key].empty?
           else
-            print_failures_from_hash(message[key], depth+1)
+            print_failures_from_hash(message[key], depth + 1)
           end
         end
       end
-      def print_key(key,depth)
-        puts (color('bright yellow',"#{key} => ")).prepend(" "*(4*depth+2))
+
+      def print_key(key, depth)
+        puts indent( color('bright yellow',"#{key} : "), depth )
       end
 
-      def print_value_diff(value,depth)
-        print (color('bright fail',"Server Value: ")).prepend(" "*(4*depth+4))
+      def print_value_diff(value, depth)
+        print indent( color('bright fail',"server value = "), depth + 1 )
         print value["server"]
         print "\n"
-        print (color('bright fail',"Local Value:  ")).prepend(" "*(4*depth+4))
+        print indent( color('bright fail',"local value  = "), depth + 1 )
         print value["local"] 
         print "\n\n"
       end
@@ -149,6 +151,10 @@ module HealthInspector
         instance ? instance.to_hash : nil
       rescue IOError
         nil
+      end
+
+      def indent(string, depth)
+        string.prepend(' ' * 2 * depth)
       end
 
     end

--- a/lib/health_inspector/checklists/base.rb
+++ b/lib/health_inspector/checklists/base.rb
@@ -77,6 +77,11 @@ module HealthInspector
         end
       end
 
+      def chef_rest 
+        @rest ||= Chef::REST.new(@context.configure[:chef_server_url], @context.configure[:node_name],
+                                 @context.configure[:client_key])
+      end
+
       def run_check(check, item)
         check_context = CheckContext.new(check, item, @context)
         check_context.call

--- a/lib/health_inspector/checklists/cookbooks.rb
+++ b/lib/health_inspector/checklists/cookbooks.rb
@@ -62,7 +62,7 @@ module HealthInspector
       end
 
       def cookbooks_on_server
-        JSON.parse( @context.knife_command("cookbook list -Fj") ).inject({}) do |hsh, c|
+        Yajl::Parser.parse( @context.knife_command("cookbook list -Fj") ).inject({}) do |hsh, c|
           name, version = c.split
           hsh[name] = version
           hsh

--- a/lib/health_inspector/checklists/cookbooks.rb
+++ b/lib/health_inspector/checklists/cookbooks.rb
@@ -54,10 +54,6 @@ module HealthInspector
       end
 
       title "cookbooks"
-      require 'chef/checksum_cache'
-      require 'chef/cookbook_version'
-      require 'chef/rest'
-      require 'pathname'
 
       def items
         server_cookbooks           = cookbooks_on_server

--- a/lib/health_inspector/checklists/data_bag_items.rb
+++ b/lib/health_inspector/checklists/data_bag_items.rb
@@ -15,7 +15,8 @@ module HealthInspector
 
       add_check "items are the same" do
         if item.server && item.local
-          failure "#{item.server}\n  is not equal to\n  #{item.local}" unless item.server == item.local
+          item_diff = diff(item.server, item.local)
+          failure item_diff unless item_diff.empty?
         end
       end
 
@@ -61,7 +62,7 @@ module HealthInspector
       end
 
       def load_item_from_local(name)
-        JSON.parse( File.read("#{@context.repo_path}/data_bags/#{name}.json") )
+        Yajl::Parser.parse( File.read("#{@context.repo_path}/data_bags/#{name}.json") )
       rescue IOError, Errno::ENOENT
         nil
       end

--- a/lib/health_inspector/checklists/environments.rb
+++ b/lib/health_inspector/checklists/environments.rb
@@ -15,8 +15,8 @@ module HealthInspector
 
       add_check "items are the same" do
         if item.server && item.local
-          environment_diff = diff(item.server,item.local)
-          failure environment_diff unless environment_diff.empty?
+          item_diff = diff(item.server, item.local)
+          failure item_diff unless item_diff.empty?
         end
       end
 

--- a/lib/health_inspector/checklists/roles.rb
+++ b/lib/health_inspector/checklists/roles.rb
@@ -17,8 +17,8 @@ module HealthInspector
 
       add_check "items are the same" do
         if item.server && item.local
-          roles_diff = diff( item.server, item.local)
-          failure roles_diff unless roles_diff.empty? 
+          item_diff = diff(item.server, item.local)
+          failure item_diff unless item_diff.empty?
         end
       end
 

--- a/lib/health_inspector/version.rb
+++ b/lib/health_inspector/version.rb
@@ -1,3 +1,3 @@
 module HealthInspector
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
I've added a new check to the cookbook check. This will pull the cookbook manifest from the server, and go file by file through the cookbook on the repo comparing the servers checksum to a checksum generated by chef on the fly for the files in the repo.

This is a good check to see if someone is uploading cookbooks to the chef server without committing them to the repo.

Also note, I'm using the Chef::REST class to retrieve information from the server. I have moved this into base, believing it might improve performance in the long run to replace the knife calls in spawned shells with a Chef::REST call.
