### PR TITLE
Changed prepend to append in checklists/base.rb:indent

### DIFF
--- a/lib/health_inspector/checklists/base.rb
+++ b/lib/health_inspector/checklists/base.rb
@@ -154,7 +154,7 @@ module HealthInspector
       end
 
       def indent(string, depth)
-        string.prepend(' ' * 2 * depth)
+        (' ' * 2 * depth) << string
       end
 
     end

--- a/lib/health_inspector/checklists/cookbooks.rb
+++ b/lib/health_inspector/checklists/cookbooks.rb
@@ -38,6 +38,10 @@ module HealthInspector
         end
       end
 
+      add_check "changes on the server not in the repo" do
+        failure "Your server has a newer version of the file" if false
+      end
+
       class Cookbook < Struct.new(:name, :path, :server_version, :local_version)
         def git_repo?
           self.path && File.exist?("#{self.path}/.git")
@@ -47,9 +51,11 @@ module HealthInspector
       title "cookbooks"
 
       def items
-        server_cookbooks   = cookbooks_on_server
-        local_cookbooks    = cookbooks_in_repo
+        server_cookbooks           = cookbooks_on_server
+        local_cookbooks            = cookbooks_in_repo
         all_cookbook_names = ( server_cookbooks.keys + local_cookbooks.keys ).uniq.sort
+        server_cbs_checksums       = cookbook_checksums_on_server( all_cookbook_names )
+        local_cbs_checksums        = cookbook_checksums_in_repo( all_cookbook_names )
 
         all_cookbook_names.map do |name|
           Cookbook.new.tap do |cookbook|
@@ -87,6 +93,14 @@ module HealthInspector
       def cookbook_path(name)
         path = @context.cookbook_path.find { |f| File.exist?("#{f}/#{name}") }
         path ? File.join(path, name) : nil
+      end
+
+      def cookbook_checksums_on_server(name)
+
+      end
+
+      def cookbook_checksums_in_repo(name)
+
       end
     end
   end


### PR DESCRIPTION
So, I realized this morning as we installed this on an older box, String#prepend is a Ruby 1.9.3 only method. Switched this to appending spaces instead.
