### PR TITLE
Use rest instead of knife in cookbooks.rb

### DIFF
--- a/lib/health_inspector/checklists/cookbooks.rb
+++ b/lib/health_inspector/checklists/cookbooks.rb
@@ -72,9 +72,8 @@ module HealthInspector
       end
 
       def cookbooks_on_server
-        Yajl::Parser.parse( @context.knife_command("cookbook list -Fj") ).inject({}) do |hsh, c|
-          name, version = c.split
-          hsh[name] = version
+        chef_rest.get_rest("/cookbooks").inject({}) do |hsh, (name,version)|
+          hsh[name] = version["versions"].first["version"]
           hsh
         end
       end

--- a/lib/health_inspector/context.rb
+++ b/lib/health_inspector/context.rb
@@ -2,10 +2,6 @@ require "chef/config"
 
 module HealthInspector
   class Context < Struct.new(:repo_path, :config_path)
-    def knife_command(subcommnad)
-      `cd #{repo_path} && knife #{subcommnad} -c #{config_path}`
-    end
-
     def cookbook_path
       Array( config.cookbook_path )
     end


### PR DESCRIPTION
Retrieves list of cookbooks with Chef::REST, removes context.rb#knife_command
