### PR TITLE
Optionally select a component to check

### DIFF
--- a/lib/health_inspector/checklists/base.rb
+++ b/lib/health_inspector/checklists/base.rb
@@ -154,7 +154,7 @@ module HealthInspector
       end
 
       def indent(string, depth)
-        string.prepend(' ' * 2 * depth)
+        (' ' * 2 * depth) << string
       end
 
     end

--- a/lib/health_inspector/cli.rb
+++ b/lib/health_inspector/cli.rb
@@ -10,9 +10,9 @@ module HealthInspector
       :default => ".chef/knife.rb",
       :banner => "Path to your knife config file."
 
-    desc "inspect", "Inspect a chef server repo"
-    def inspect
-      Inspector.inspect(options[:repopath], options[:configpath])
+    desc "inspect [COMPONENT]", "Inspect a chef repo. Optionally, specify an individual chef component to inspect. One of cookbooks, databags, databagitems, environments, roles"
+    def inspect(component='')
+      Inspector.inspect(component,options[:repopath], options[:configpath])
     end
   end
 end

--- a/lib/health_inspector/inspector.rb
+++ b/lib/health_inspector/inspector.rb
@@ -1,7 +1,27 @@
 module HealthInspector
   class Inspector
-    def self.inspect(repo_path, config_path)
-      new(repo_path, config_path).inspect
+    def self.inspect(component,repo_path, config_path)
+      new(repo_path, config_path).inspect(classify(component))
+    end
+
+    def self.classify(component)
+      case component.downcase
+      when "cookbooks"
+        "Cookbooks"
+      when "databags"
+        "DataBags"
+      when "databagitems"
+        "DataBagItems"
+      when "environments"
+        "Environments"
+      when "roles"
+        "Roles"
+      when "all"
+        ''
+      else
+        puts "I did not understand which component you wanted me to inspect. Running all checks."
+        ''
+      end
     end
 
     def initialize(repo_path, config_path)
@@ -9,12 +29,16 @@ module HealthInspector
       @context.configure
     end
 
-    def inspect
-      Checklists::Cookbooks.run(@context)
-      Checklists::DataBags.run(@context)
-      Checklists::DataBagItems.run(@context)
-      Checklists::Environments.run(@context)
-      Checklists::Roles.run(@context)
+    def inspect(component)
+      if component.empty?
+        Checklists::Cookbooks.run(@context)
+        Checklists::DataBags.run(@context)
+        Checklists::DataBagItems.run(@context)
+        Checklists::Environments.run(@context)
+        Checklists::Roles.run(@context)
+      else
+        Checklists.const_get(component).run(@context)
+      end
     end
   end
 end


### PR DESCRIPTION
A requested feature at my company, this adds the ability to select an individual component to run checks for.

No change in original run, so

> health_inspector inspect

works as expected. Also

> health_inspector inspect all

works the same. This pull request allows

> health_inspector inspect environments

which only runs the environment checks. Components line up with checks, so: cookbooks, databags, databagitems, environments, roles
