### PR TITLE
Continue run on json parse error

### DIFF
--- a/lib/health_inspector/checklists/data_bag_items.rb
+++ b/lib/health_inspector/checklists/data_bag_items.rb
@@ -65,7 +65,7 @@ module HealthInspector
 
       def load_item_from_local(name)
         Yajl::Parser.parse( File.read("#{@context.repo_path}/data_bags/#{name}.json") )
-      rescue IOError, Errno::ENOENT
+      rescue IOError, Errno::ENOENT, Yajl::ParseError
         nil
       end
     end


### PR DESCRIPTION
We should continue to check databags even when a json parse error occurs.
We also could better handle the parse error with descriptive message.
Here, the behavior is that health_inspector will yield that a local data bag item is different from the server one.
Later, the chef-server doesn't accept invalid json to be uploaded.
This behavior also applies to roles, this pull request doesn't fix the roles.
