### PR TITLE
Added quiet_success and no_color options

### DIFF
--- a/lib/health_inspector/checklists/base.rb
+++ b/lib/health_inspector/checklists/base.rb
@@ -34,7 +34,7 @@ module HealthInspector
           failures = run_checks(item)
 
           if failures.empty?
-            print_success(item.name)
+            print_success(item.name) unless @context.quiet_success
           else
             print_failures(item.name, failures)
           end

--- a/lib/health_inspector/cli.rb
+++ b/lib/health_inspector/cli.rb
@@ -4,11 +4,19 @@ module HealthInspector
   class CLI < Thor
     class_option 'repopath', :type => :string, :aliases => "-r",
       :default => ".",
-      :banner => "Path to your local chef-repo"
+      :banner => "Path to your local chef-repo."
 
     class_option 'configpath', :type => :string, :aliases => "-c",
       :default => ".chef/knife.rb",
       :banner => "Path to your knife config file."
+
+    class_option 'no-color', :type => :boolean,
+      :default => false,
+      :banner => "Suppress output of ansi color messages."
+
+    class_option 'quiet-success', :type => :boolean, :aliases => "-q",
+      :default => false,
+      :banner => "Suppress output of successful checks."
 
     default_task :inspect
 
@@ -19,7 +27,7 @@ Inspect a chef repo. Optionally, specify one component to inspect:
 
     def inspect(component="")
       checklists = component_to_checklists(component)
-      Inspector.inspect( checklists ,options[:repopath], options[:configpath])
+      Inspector.inspect( checklists, options)
     end
 
     protected

--- a/lib/health_inspector/color.rb
+++ b/lib/health_inspector/color.rb
@@ -23,7 +23,11 @@ module HealthInspector
         'diff removed'  => 41
       }
 
+      if @context.no_color
+        str
+      else
       "\e[%sm%s\e[0m" % [ colors[type], str ]
+      end
     end
   end
 end

--- a/lib/health_inspector/context.rb
+++ b/lib/health_inspector/context.rb
@@ -2,6 +2,9 @@ require "chef/config"
 
 module HealthInspector
   class Context < Struct.new(:repo_path, :config_path)
+
+    attr_accessor :no_color, :quiet_success
+
     def cookbook_path
       Array( config.cookbook_path )
     end

--- a/lib/health_inspector/inspector.rb
+++ b/lib/health_inspector/inspector.rb
@@ -1,11 +1,13 @@
 module HealthInspector
   class Inspector
-    def self.inspect(checklists, repo_path, config_path)
-      new(repo_path, config_path).inspect( checklists )
+    def self.inspect(checklists, options)
+      new(options).inspect( checklists )
     end
 
-    def initialize(repo_path, config_path)
-      @context = Context.new( repo_path, config_path )
+    def initialize(options)
+      @context = Context.new( options[:repopath], options[:configpath] )
+      @context.quiet_success = options[:'quiet-success']
+      @context.no_color      = options[:'no-color']
       @context.configure
     end
 


### PR DESCRIPTION
When run on windows or another environment without ansi colors, the output of health_inspector is ugly. Determining if color is available is Hard(tm). I added a command line option to optionally just stop color output.

Also, I added the quiet option, which only shows failures.
