### PR TITLE
Attempt to find config file relative to PWD in case there is a require error

### DIFF
--- a/lib/health_inspector/context.rb
+++ b/lib/health_inspector/context.rb
@@ -14,7 +14,11 @@ module HealthInspector
     end
 
     def configure
-      Chef::Config.from_file(config_path)
+      begin
+        Chef::Config.from_file(config_path)
+      rescue LoadError
+        Chef::Config.from_file("#{ENV['PWD']}/#{config_path}")
+      end
       Chef::Config
     end
 


### PR DESCRIPTION
- if you require any relative files in .chef/knife.rb, an error is
  thrown in Mixlib::Config due to an instance_eval that loses file
  context. If this happens, attempt to find the config relative
  to PWD.

This is such an edge case, I didn't think a specific test was necessary. I'll write one if you prefer, though.
